### PR TITLE
Fix error when returning Unit

### DIFF
--- a/android/src/main/kotlin/nl/dutchcodingcompany/pin_lock/PinLockPlugin.kt
+++ b/android/src/main/kotlin/nl/dutchcodingcompany/pin_lock/PinLockPlugin.kt
@@ -32,7 +32,7 @@ class PinLockPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                         }
                     }
                 }
-                result.success(Unit)
+                result.success(null)
             }
             else -> result.notImplemented()
         }


### PR DESCRIPTION
Fixes #5 

Returns `null` instead of `Unit`. Flutter MethodChannel doesn't support Kotlin `Unit` type.