### PR TITLE
Fix/fix overlay safe call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+
+- reverted removing of safe-calls on overlays. They are only for flutter >= 3.7.0.
+- Changed flutter sdk limit from >= 1.20.0 to  >= 3.0.0
+
 ## 0.0.3
 
 - Changed `lint` package to `flutter_lints` #12

--- a/lib/src/presentation/authenticator_widget.dart
+++ b/lib/src/presentation/authenticator_widget.dart
@@ -96,7 +96,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
             ),
           );
           if (!_isShowingSplashScreen) {
-            Overlay.of(context).insert(overlayEntry!);
+            Overlay.of(context)?.insert(overlayEntry!);
           }
         }
       }
@@ -105,7 +105,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
       setState(() {
         _isShowingSplashScreen = false;
         if (overlayEntry != null) {
-          Overlay.of(context).insert(overlayEntry!);
+          Overlay.of(context)?.insert(overlayEntry!);
         }
       });
     });

--- a/lib/src/presentation/authenticator_widget.dart
+++ b/lib/src/presentation/authenticator_widget.dart
@@ -96,6 +96,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
             ),
           );
           if (!_isShowingSplashScreen) {
+            // As of flutter 3.7.0 these will be non-null. For they are kept in place.
             Overlay.of(context)?.insert(overlayEntry!);
           }
         }
@@ -105,6 +106,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
       setState(() {
         _isShowingSplashScreen = false;
         if (overlayEntry != null) {
+          // As of flutter 3.7.0 these will be non-null. For they are kept in place.
           Overlay.of(context)?.insert(overlayEntry!);
         }
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/DutchCodingCompany/pin_lock
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pin_lock
 
-version: 0.0.3
+version: 0.0.4
 
 description: "A full solution to local authentication: it contains authentication logic and tracks authentication-relevant data, while providing an interface for app-specific UI implementatin."
 


### PR DESCRIPTION
- reverted removing of safe-calls on overlays. They are only for flutter >= 3.7.0.
- Changed flutter sdk limit from >= 1.20.0 to  >= 3.0.0