### PR TITLE
Should hide or show content when rebuilding the Authentication widget

### DIFF
--- a/lib/src/presentation/authenticator_widget.dart
+++ b/lib/src/presentation/authenticator_widget.dart
@@ -76,10 +76,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
   void initState() {
     super.initState();
     lockState = widget.authenticator.lockState;
-    PinLock.setHideAppContent(
-      preference: widget.hideAppContent,
-      iosAssetImage: widget.iosImageAsset,
-    );
+
     lockSubscription = lockState.listen((event) {
       if (event is Unlocked) {
         overlayEntry?.remove();
@@ -123,6 +120,10 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
 
   @override
   Widget build(BuildContext context) {
+    PinLock.setHideAppContent(
+      preference: widget.hideAppContent,
+      iosAssetImage: widget.iosImageAsset,
+    );
     return StreamBuilder<LockState>(
       stream: lockState,
       builder: (context, snapshot) {


### PR DESCRIPTION
Here's my reason for this PR. I'm using bloc to build the Authentication widget:

```
    return BlocBuilder<AppSettingsBloc, AppSettingsState>(
      builder: (context, state) {
        return AuthenticatorWidget(
          authenticator: globalAuthenticator,
          userFacingBiometricAuthenticationMessage: 'security.biometric_authentication_message'.tr(),
          inputNodeBuilder: (index, state) => Container(),
          lockScreenBuilder: (configuration) => ScreenLockWidget(
            title: 'security.enter_your_pin'.tr(),
            globalAuthenticator: globalAuthenticator,
            configuration: configuration,
          ),
          // iosImageAsset: 'AppIcon',
          hideAppContent: state.pinLockEnabled,
          child: App(),
        );
      },
    );
  }
}
```

However whenever the bloc state is changed because `pinLockEnabled` changes, the method `PinLock.setHideAppContent()` is not called because it's used inside the `initState` method of AuthenticationWidget, thus it does not show or hide the screen content accordingly.
So I think we can call `PinLock.setHideAppContent()` in the build method of AuthenticationWidget, that will make sure whenever the `hideAppContent` value change, it will surely call the native method.