### PR TITLE
Only save pause timestamp if app is unlocked

### DIFF
--- a/lib/src/entities/authenticator_impl.dart
+++ b/lib/src/entities/authenticator_impl.dart
@@ -60,6 +60,7 @@ class AuthenticatorImpl with WidgetsBindingObserver implements Authenticator {
         /// When the app is [paused], it first goes to [inactive] before continuing to [resumed]
         /// Ensure that the paused timestamp is not saved just before the app becomes [resumed]
         if (_lastState != AppLifecycleState.paused) {
+            _lockController.lockState is Unlocked) {
           _repository.savePausedTimestamp(DateTime.now());
         }
         break;

--- a/lib/src/entities/authenticator_impl.dart
+++ b/lib/src/entities/authenticator_impl.dart
@@ -59,7 +59,7 @@ class AuthenticatorImpl with WidgetsBindingObserver implements Authenticator {
 
         /// When the app is [paused], it first goes to [inactive] before continuing to [resumed]
         /// Ensure that the paused timestamp is not saved just before the app becomes [resumed]
-        if (_lastState != AppLifecycleState.paused) {
+        if (_lastState != AppLifecycleState.paused &&
             _lockController.lockState is Unlocked) {
           _repository.savePausedTimestamp(DateTime.now());
         }

--- a/lib/src/entities/lock_controller.dart
+++ b/lib/src/entities/lock_controller.dart
@@ -12,6 +12,9 @@ class LockController {
   /// state of the app
   late final Stream<LockState> state;
 
+  // The current lock state of the app
+  late LockState lockState = const Unlocked();
+
   /// Optionally register a callback that gets triggered every time the app is locked
   /// (e.g., for analytics purposes)
   final VoidCallback? onLockCallback;
@@ -36,13 +39,15 @@ class LockController {
   /// [availableMethods] refer to [BiometricMethod]s that the device supports, or an empty list if the
   /// device doesn't support biometrics or the user has not opted in to using it.
   void lock({required List<BiometricMethod> availableMethods}) {
-    _streamController.add(Locked(availableBiometricMethods: availableMethods));
+    lockState = Locked(availableBiometricMethods: availableMethods);
+    _streamController.add(lockState);
   }
 
   /// Results in dismissing the lock screen overlay and making the app contents visible.
   /// Probably shouldn't be used manually, unless there's a really good reason to. It was
   /// intended to be used by the pin_lock package internally
   void unlock() {
-    _streamController.add(const Unlocked());
+    lockState = const Unlocked();
+    _streamController.add(lockState);
   }
 }


### PR DESCRIPTION
Hello,

I have identified and addressed an issue related to the didChangeAppLifecycleState behavior when interacting with Face ID. During the 'unlockWithBiometrics' , didChangeAppLifecycleState receives an inactive/paused state. This led to the unintended triggering of the lockout duration check immediately after the Face ID authentication was completed.

There seems to be an inconsistnty in how often didChangeAppLifecycleState recieves this state.

The problematic sequence was as follows:

1. The lock screen was displayed.
2. The Face ID popup opened, and the app's state was marked as 'inactive' while waiting for Face ID authentication.
3. Upon successful Face ID authentication and app reactivation, the didChangeAppLifecycleState received the resume even and 'paused timestamp' is then checked against the current time.
4. Due to the passing of the lock duration check, the lock screen was shown again.

This behavior was not isolated to our app but was also observed in your example application.

To rectify this issue, I have modified the behavior to consider the app's lock status before storing the 'paused timestamp'. It is unnecessary to execute the lock duration check if the app is already in a locked state when it goes inactive.

I'm currently uncertain about how best to retreive the current lock status so i have made a slight change to lock_controller.dart. Happy to change this ofcourse. 

Your feedback on this approach and its integration into the existing codebase would be greatly appreciated. Thank you for your attention to this matter.

Best regards,
Charlton Santana





