### PR TITLE
fix: renaming LockState to PinLockState

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'nl.dutchcodingcompany.pin_lock'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '2.0.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,7 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
+    namespace 'nl.dutchcodingcompany.pin_lock'
 }
 
 dependencies {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true

--- a/lib/src/entities/authenticator.dart
+++ b/lib/src/entities/authenticator.dart
@@ -12,8 +12,8 @@ abstract class Authenticator with WidgetsBindingObserver {
   /// Interval after which the app will become pin locked after entering the background
   Duration get lockAfterDuration;
 
-  /// Emits a [LockState] event every time the state is changed
-  Stream<LockState> get lockState;
+  /// Emits a [PinLockState] event every time the state is changed
+  Stream<PinLockState> get lockState;
 
   /// The number of times that a pin can be entered incorrectly, before the app
   /// stops accepting unlock attempts for [lockedOutDuration]

--- a/lib/src/entities/authenticator_impl.dart
+++ b/lib/src/entities/authenticator_impl.dart
@@ -38,7 +38,7 @@ class AuthenticatorImpl with WidgetsBindingObserver implements Authenticator {
   );
 
   @override
-  Stream<LockState> get lockState {
+  Stream<PinLockState> get lockState {
     _checkInitialLockStatus();
     return _lockController.state;
   }

--- a/lib/src/entities/lock_controller.dart
+++ b/lib/src/entities/lock_controller.dart
@@ -8,9 +8,9 @@ import 'package:pin_lock/src/entities/lock_state.dart';
 /// It allows registering callbacks that will get triggered when the
 /// app is locked/unlocked (e.g., for analytics purposes)
 class LockController {
-  /// The stream of [LockState] where the last entry is always the current
+  /// The stream of [PinLockState] where the last entry is always the current
   /// state of the app
-  late final Stream<LockState> state;
+  late final Stream<PinLockState> state;
 
   /// Optionally register a callback that gets triggered every time the app is locked
   /// (e.g., for analytics purposes)
@@ -20,7 +20,7 @@ class LockController {
   /// (e.g., for analytics purposes)
   final VoidCallback? onUnlockCallback;
 
-  final StreamController<LockState> _streamController;
+  final StreamController<PinLockState> _streamController;
 
   LockController({this.onUnlockCallback, this.onLockCallback})
       : _streamController = StreamController.broadcast() {

--- a/lib/src/entities/lock_state.dart
+++ b/lib/src/entities/lock_state.dart
@@ -1,13 +1,13 @@
 import 'package:equatable/equatable.dart';
 import 'package:pin_lock/src/entities/biometric_method.dart';
 
-abstract class LockState extends Equatable {
-  const LockState();
+abstract class PinLockState extends Equatable {
+  const PinLockState();
   @override
   List<Object?> get props => [];
 }
 
-class Locked extends LockState {
+class Locked extends PinLockState {
   final List<BiometricMethod> availableBiometricMethods;
 
   const Locked({required this.availableBiometricMethods});
@@ -16,6 +16,6 @@ class Locked extends LockState {
   List<Object?> get props => [availableBiometricMethods];
 }
 
-class Unlocked extends LockState {
+class Unlocked extends PinLockState {
   const Unlocked() : super();
 }

--- a/lib/src/presentation/authenticator_widget.dart
+++ b/lib/src/presentation/authenticator_widget.dart
@@ -70,7 +70,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
   late final StreamSubscription lockSubscription;
   OverlayEntry? overlayEntry;
   bool _isShowingSplashScreen = true;
-  late final Stream<LockState> lockState ;
+  late final Stream<PinLockState> lockState;
 
   @override
   void initState() {
@@ -123,7 +123,7 @@ class _AuthenticatorWidgetState extends State<AuthenticatorWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<LockState>(
+    return StreamBuilder<PinLockState>(
       stream: lockState,
       builder: (context, snapshot) {
         if (snapshot.hasData && !_isShowingSplashScreen) {


### PR DESCRIPTION
This PR renames the variable LockState to PinLockState.

The [latest version of Flutter now includes "LockState"](https://api.flutter.dev/flutter/widgets/LockState.html), so there is a conflict in this package, not allowing it to be used.

This can be a breaking change for existing users of the package currently referring to LockState.